### PR TITLE
Changes the filtering while creating the stacktrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bugsnag"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Bastian Köcher <git@kchr.de>"]
 description = "The api of Bugsnag in rust."
 documentation = "https://docs.rs/bugsnag/"

--- a/README.md
+++ b/README.md
@@ -18,11 +18,19 @@ api.set_app_info(Some(env!("CARGO_PKG_VERSION")),
                  Some("development"),
                  Some("rust"));
 
-let stacktrace = bugsnag::stacktrace::create_stacktrace(
-    Some(&|file, _| file.starts_with(env!("CARGO_MANIFEST_DIR"))));
-
 api.notify("Info", "This is a message from the rust bugsnag api.",
-           bugsnag::Severity::Info, &stacktrace, None); 
+           bugsnag::Severity::Info, None, None); 
+```
+
+Or in a panic handler you could do the following:
+
+```rust
+
+use bugsnag;
+let mut api = bugsnag::Bugsnag::new("api-key", env!("CARGO_MANIFEST_DIR"));
+
+bugsnag::panic::handle(&api, panic_info, None);
+
 ```
 
 For more examples on how to integrate bugsnag into a project, the examples folder provides some reference implementations.

--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ The Bugsnag api in rust.
 
 ```rust
 use bugsnag;
-let mut api = bugsnag::Bugsnag::new("api-key", Some(env!("CARGO_MANIFEST_DIR")));
+let mut api = bugsnag::Bugsnag::new("api-key", env!("CARGO_MANIFEST_DIR"));
 
 // setting the appinfo is not required, but recommended 
 api.set_app_info(Some(env!("CARGO_PKG_VERSION")),
                  Some("development"),
                  Some("rust"));
 
-let stacktrace = bugsnag::stacktrace::create_stacktrace(api.get_project_source_dir());
+let stacktrace = bugsnag::stacktrace::create_stacktrace(
+    Some(&|file, _| file.starts_with(env!("CARGO_MANIFEST_DIR"))));
 
 api.notify("Info", "This is a message from the rust bugsnag api.",
            bugsnag::Severity::Info, &stacktrace, None); 

--- a/examples/log_integration.rs
+++ b/examples/log_integration.rs
@@ -9,8 +9,6 @@ extern crate log;
 
 use log::{LogRecord, LogLevel, LogMetadata, SetLoggerError};
 
-use bugsnag::stacktrace;
-
 /// Our logger for bugsnag
 struct BugsnagLogger {
     max_loglevel: LogLevel,
@@ -46,16 +44,13 @@ impl log::Log for BugsnagLogger {
     fn log(&self, record: &LogRecord) {
         if self.enabled(record.metadata()) {
             let level = convert_log_level(record.metadata().level());
-            let project_path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples");
-            let stacktrace = stacktrace::create_stacktrace(Some(&|file, method| {
-                file.starts_with(project_path) &&
-                    !method.contains("register_panic_handler_with_global_instance")
-            }));
-            self.api.notify(record.metadata().level().to_string().as_str(),
-                            record.args().to_string().as_str(),
-                            level,
-                            &stacktrace,
-                            None).unwrap();
+            self.api
+                .notify(record.metadata().level().to_string().as_str(),
+                        record.args().to_string().as_str(),
+                        level,
+                        None,
+                        None)
+                .unwrap();
         }
     }
 }

--- a/examples/simple_panic_handler.rs
+++ b/examples/simple_panic_handler.rs
@@ -13,12 +13,18 @@ use std::panic;
 /// the object are possible
 fn register_panic_handler(api: bugsnag::Bugsnag) {
     panic::set_hook(Box::new(move |info| {
-        let message = match info.payload().downcast_ref::<&str>() {
-            Some(msg) => msg,
-            None => "unknown error!",
+        let message = if info.payload().is::<String>() {
+            info.payload().downcast_ref::<String>().unwrap().as_str()
+        } else if info.payload().is::<&str>() {
+            info.payload().downcast_ref::<&str>().unwrap()
+        } else {
+            "Unknown error!"
         };
 
-        let stacktrace = stacktrace::create_stacktrace(api.get_project_source_dir());
+        let project_path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples");
+        let stacktrace = stacktrace::create_stacktrace(Some(&|file, method| {
+            file.starts_with(project_path) && !method.contains("register_panic_handler")
+        }));
 
         if api.notify("Panic",
                     message,
@@ -31,13 +37,19 @@ fn register_panic_handler(api: bugsnag::Bugsnag) {
     }));
 }
 
+fn test() -> Option<i32> { 
+    None
+}
+
 fn main() {
-    let mut api = bugsnag::Bugsnag::new("api-key", Some(env!("CARGO_MANIFEST_DIR")));
+    let mut api = bugsnag::Bugsnag::new("api-key", concat!(env!("CARGO_MANIFEST_DIR"), "/examples"));
     api.set_app_info(Some(env!("CARGO_PKG_VERSION")),
                      Some("development"),
                      Some("rust"));
 
     register_panic_handler(api);
+
+    test().unwrap();
 
     panic!("Hello from a Rust panic!");
 }

--- a/src/bugsnag_impl.rs
+++ b/src/bugsnag_impl.rs
@@ -26,19 +26,19 @@ pub enum Severity {
 
 pub struct Bugsnag {
     api_key: String,
-    project_source_dir: Option<String>,
     device_info: deviceinfo::DeviceInfo,
     app_info: Option<appinfo::AppInfo>,
+    project_source_dir: String,
 }
 
 impl Bugsnag {
     /// Creates a new instance of the Bugsnag api
-    pub fn new(api_key: &str, proj_source_dir: Option<&str>) -> Bugsnag {
+    pub fn new(api_key: &str, project_source_dir: &str) -> Bugsnag {
         Bugsnag {
             api_key: api_key.to_owned(),
-            project_source_dir: proj_source_dir.map(|s| s.to_string()),
             device_info: deviceinfo::DeviceInfo::generate(),
             app_info: None,
+            project_source_dir: project_source_dir.to_owned(),
         }
     }
 
@@ -76,11 +76,6 @@ impl Bugsnag {
         }
     }
 
-    /// Returns the path to the project source directory
-    pub fn get_project_source_dir(&self) -> &Option<String> {
-        &self.project_source_dir
-    }
-
     /// Sets information about the device. These information will be send to
     /// Bugsnag when notify is called.
     pub fn set_device_info(&mut self, hostname: Option<&str>, version: Option<&str>) {
@@ -105,11 +100,15 @@ impl Bugsnag {
     pub fn reset_app_info(&mut self) {
         self.app_info = None;
     }
+
+    pub fn get_project_source_dir(&self) -> &String {
+        &self.project_source_dir
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Bugsnag, Severity};
+    use super::{Severity, Bugsnag};
     use serde_test::{Token, assert_ser_tokens};
 
     #[test]
@@ -134,9 +133,8 @@ mod tests {
     }
 
     #[test]
-    fn test_get_project_source_dir() {
-        let api = Bugsnag::new("api-key", Some("my/project/path"));
-        let source_dir = api.get_project_source_dir().as_ref().unwrap();
-        assert_eq!(source_dir, "my/project/path");
+    fn test_get_project_dir() {
+        let api = Bugsnag::new("api-key", "my-dir");
+        assert_eq!(api.get_project_source_dir(), "my-dir");
     }
 }

--- a/src/deviceinfo.rs
+++ b/src/deviceinfo.rs
@@ -53,4 +53,21 @@ mod tests {
                             Token::Str("testmachine"),
                             Token::StructEnd]);
     }
+
+    #[test]
+    fn test_deviceinfo_to_json_with_set() {
+        let mut info = DeviceInfo::generate();
+        info.set_hostname("testmachine3");
+        info.set_os_version("3.0.0");
+
+        assert_ser_tokens(&info,
+                          &[Token::StructStart("DeviceInfo", 2),
+                            Token::StructSep,
+                            Token::Str("osVersion"),
+                            Token::Str("3.0.0"),
+                            Token::StructSep,
+                            Token::Str("hostname"),
+                            Token::Str("testmachine3"),
+                            Token::StructEnd]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,8 @@
 //!                  Some("development"),
 //!                  Some("rust"));
 //!
-//! let stacktrace = bugsnag::stacktrace::create_stacktrace(
-//!     Some(&|file, _| file.starts_with(env!("CARGO_MANIFEST_DIR"))));
-//!
 //! api.notify("Info", "This is a message from the rust bugsnag api.",
-//!            bugsnag::Severity::Info, &stacktrace, None); 
+//!            bugsnag::Severity::Info, None, None); 
 //! ```
 //!
 //! For more examples on how to integrate bugsnag into a project, the examples
@@ -34,9 +31,10 @@ extern crate sys_info;
 
 mod event;
 mod notification;
-pub mod stacktrace;
+mod stacktrace;
 mod exception;
 mod bugsnag_impl;
 pub use self::bugsnag_impl::*;
 mod deviceinfo;
 mod appinfo;
+pub mod panic;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,15 @@
 //!
 //! ```
 //! use bugsnag;
-//! let mut api = bugsnag::Bugsnag::new("api-key", Some(env!("CARGO_MANIFEST_DIR")));
+//! let mut api = bugsnag::Bugsnag::new("api-key", env!("CARGO_MANIFEST_DIR"));
 //!
 //! // setting the appinfo is not required, but recommended 
 //! api.set_app_info(Some(env!("CARGO_PKG_VERSION")),
 //!                  Some("development"),
 //!                  Some("rust"));
 //!
-//! let stacktrace = bugsnag::stacktrace::create_stacktrace(api.get_project_source_dir());
+//! let stacktrace = bugsnag::stacktrace::create_stacktrace(
+//!     Some(&|file, _| file.starts_with(env!("CARGO_MANIFEST_DIR"))));
 //!
 //! api.notify("Info", "This is a message from the rust bugsnag api.",
 //!            bugsnag::Severity::Info, &stacktrace, None); 

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,22 @@
+use super::{Bugsnag, Severity, Error};
+
+use std::panic::PanicInfo;
+
+pub fn handle(api: &Bugsnag,
+              info: &PanicInfo,
+              methods_to_ignore: Option<&[&str]>)
+              -> Result<(), Error> {
+    let message = if let Some(data) = info.payload().downcast_ref::<String>() {
+        data.to_owned()
+    } else if let Some(data) = info.payload().downcast_ref::<&str>() {
+        (*data).to_owned()
+    } else {
+        format!("Error: {:?}", info.payload())
+    };
+
+    api.notify("Panic",
+               message.as_str(),
+               Severity::Error,
+               methods_to_ignore,
+               None)
+}


### PR DESCRIPTION
- The create_stacktrace now takes a function that is called to check if a file
  belongs to a project
- Removes the project_source_dir attribute from the Bugsnag api as it is not
  required for any internal use
- Improves the examples by showing how to extract str and String for panics
- Increases the version number for a new update on crates.io